### PR TITLE
Fix altering initial options array

### DIFF
--- a/jquery-bigtext.js
+++ b/jquery-bigtext.js
@@ -60,11 +60,11 @@ Copyright (C) 2013 Daniel Hoffmann Bernardes, Icaro Technologies
 			
             if (options.padding !== null) {
                 if (typeof options.padding === "number") {
-                    options.padding = options.padding + "px";
+                    options.padding = options.padding;
                 } else {
                     throw "bigText error: Padding value must be a number";
                 }
-                $this.parent().css("padding", options.padding);
+                $this.parent().css("padding", options.padding + "px");
             }
 			
 			


### PR DESCRIPTION
When you call bigText with static padding on multiple elements selector. You get your options modified and second element throws error: "padding must be number".

Example: http://jsfiddle.net/p8Aq7/
Solved: http://jsfiddle.net/dyRwy/
