### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "jquery-bigtext",
+  "version": "1.3.0",
+  "homepage": "https://github.com/DanielHoffmann/jquery-bigtext",
+  "authors": [
+    "David Barker; Maxim Novoselov; Jay Falco"
+  ],
+  "description": "jQuery plugin that makes HTML text tags as big as possible while still fitting on the parent",
+  "keywords": [
+    "jquery",
+    "bigtext",
+    "text"
+  ],
+  "main": "jquery-bigtext.js",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "bower.json",
+    "CONTRIBUTORS.md",
+    "LICENSE",
+    "README.md",
+    "examples"
+  ]
+}


### PR DESCRIPTION
I registered the package with `bower` so that people can more conveniently install it.

`bower install --save jquery-bigtext`

See: http://bob.yexley.net/creating-and-maintaining-your-own-bower-package/

The package is linked to `git://github.com/pztrick/jquery-bigtext` and when this pull request is merged we can update the bower registry to the original repo URL.
